### PR TITLE
adding conditional statements to avoid broken links downstream

### DIFF
--- a/documentation/src/main/asciidoc/user_guide/counters.adoc
+++ b/documentation/src/main/asciidoc/user_guide/counters.adoc
@@ -173,7 +173,9 @@ RemoteCacheManager manager = ...;
 CounterManager counterManager = RemoteCounterManagerFactory.asCounterManager(manager);
 ----
 
-NOTE: Hot Rod messages format can be found in link:../contributing/contributing.html#hot_rod_protocol_2_7[Hot Rod Protocol 2.7]
+ifndef::productized[]
+NOTE: Hot Rod message formats can be found in link:../contributing/contributing.html#hot_rod_protocol_2_7[Hot Rod Protocol 2.7]
+endif::productized[]
 
 ==== Remove a counter via CounterManager
 

--- a/documentation/src/main/asciidoc/user_guide/server_protocols.adoc
+++ b/documentation/src/main/asciidoc/user_guide/server_protocols.adoc
@@ -41,7 +41,14 @@ So, now that it's clear when it makes sense to deploy {brandname} in client-serv
 
 Here's a brief summary of the available server endpoints.
 
-* *Hot Rod Server Module* - This module is an implementation of the link:../contributing/contributing.html#hot_rod_protocol[Hot Rod binary protocol] backed by {brandname} which allows clients to do dynamic load balancing and failover and smart routing.
+* *Hot Rod Server Module* - This module is an implementation of the
+ifndef::productized[]
+link:../contributing/contributing.html#hot_rod_protocol[Hot Rod binary protocol]
+endif::productized[]
+ifdef::productized[]
+Hot Rod binary protocol
+endif::productized[]
+backed by {brandname} which allows clients to do dynamic load balancing and failover and smart routing.
  - A link:http://www.infinispan.org/hotrod-clients[variety of clients] exist for this protocol.
  - If you're clients are running Java, this should be your defacto server module choice because it allows for dynamic load balancing and failover. This means that Hot Rod clients can dynamically detect changes in the topology of Hot Rod servers as long as these are clustered, so when new nodes join or leave, clients update their Hot Rod server topology view. On top of that, when Hot Rod servers are configured with distribution, clients can detect where a particular key resides and so they can route requests smartly.
  - Load balancing and failover is dynamically provided by Hot Rod client implementations using information provided by the server.

--- a/documentation/src/main/asciidoc/user_guide/server_protocols_hotrod.adoc
+++ b/documentation/src/main/asciidoc/user_guide/server_protocols_hotrod.adoc
@@ -11,9 +11,13 @@ tools such as link:#integrations_hibernate_ogm[Hibernate OGM].
 ===  Java Hot Rod client
 Hot Rod is a binary, language neutral protocol. This article explains how a Java client can interact with a server via the Hot Rod protocol. A reference implementation of the protocol written in Java can be found in all {brandname} distributions, and this article focuses on the capabilities of this java client.
 
+ifndef::productized[]
 TIP: Looking for more clients?  Visit link:http://infinispan.org/hotrod-clients[this website] for clients written in a variety of different languages.
+endif::productized[]
 
+ifndef::productized[]
 TIP: Interested in the Hot Rod wire protocol ? Check the link:../contributing/contributing.html#hot_rod_protocol[Hot Rod chapter] of the contributing guide.
+endif::productized[]
 
 ==== Configuration
 The Java Hot Rod client can be configured both programmatically and externally, through a configuration file.


### PR DESCRIPTION
RH doc tooling can't handle relative links to books `link:../` We also do not plan to publish the contributors guide downstream so those links should be filtered from the productized docs.