### PR TITLE
[#17267] Test: docs-only PR (should build docs only, skip tests)

### DIFF
--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -29,6 +29,7 @@ jobs:
          pull-request-number: ${{ steps.workflow-run-info.outputs.pull-request-number }}
          source-head-branch: ${{ steps.workflow-run-info.outputs.source-head-branch }}
          source-event: ${{ github.event.workflow_run.event }}
+         build-type: ${{ steps.build-type.outputs.build-type }}
       steps:
          - uses: actions/checkout@v6
            with:
@@ -44,9 +45,23 @@ jobs:
             head-branch: ${{ github.event.workflow_run.head_branch }}
             event: ${{ github.event.workflow_run.event }}
 
+         - name: Download build type
+           uses: actions/download-artifact@v8.0.1
+           with:
+             name: build-type
+             run-id: ${{ github.event.workflow_run.id }}
+             github-token: ${{ github.token }}
+
+         - name: Read build type
+           id: build-type
+           run: |
+             BUILD_TYPE=$(cat build-type.txt)
+             echo "build-type=$BUILD_TYPE" >> "$GITHUB_OUTPUT"
+             echo "Build type: $BUILD_TYPE"
+
   ci-build-test-pr:
     needs: get-info
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.get-info.outputs.build-type == 'full' }}
     name: Maven Test
     runs-on: ubuntu-latest
     env:
@@ -262,7 +277,7 @@ jobs:
 
   targets-test:
     needs: get-info
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.get-info.outputs.build-type == 'full' }}
     name: ${{ matrix.targets == 'tomcat' && 'tomcat' || format('db ({0})', matrix.targets) }}
     runs-on: ubuntu-latest
     env:
@@ -427,7 +442,7 @@ jobs:
 
   rolling-upgrades-matrix:
     needs: get-info
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.get-info.outputs.build-type == 'full' }}
     name: "Rolling Upgrades (${{ matrix.targets.name }})"
     strategy:
       fail-fast: false
@@ -450,7 +465,7 @@ jobs:
 
   coverage:
     needs: [get-info, ci-build-test-pr, targets-test, rolling-upgrades-matrix]
-    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.get-info.outputs.source-event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.get-info.outputs.source-event == 'pull_request' && needs.get-info.outputs.build-type == 'full' }}
     name: Publish Coverage Report
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/on_propen_push_do_build.yml
+++ b/.github/workflows/on_propen_push_do_build.yml
@@ -108,5 +108,5 @@ jobs:
         uses: ./.github/actions/setup-java
 
       - name: Build Documentation
-        run: ./mvnw install -B -pl documentation -am -DskipTests
+        run: ./mvnw install -B -pl documentation -am -DskipTests -Pdocumentation
 

--- a/.github/workflows/on_propen_push_do_build.yml
+++ b/.github/workflows/on_propen_push_do_build.yml
@@ -18,7 +18,66 @@ concurrency:
 
 jobs:
 
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      build-type: ${{ steps.check.outputs.build-type }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine build type
+        id: check
+        run: |
+          BUILD_TYPE=""
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.sha }})
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              BUILD_TYPE="full"
+            fi
+            CHANGED=$(git diff --name-only "$BEFORE" "${{ github.sha }}" 2>/dev/null || true)
+          fi
+
+          if [ -z "$BUILD_TYPE" ]; then
+            echo "Changed files:"
+            echo "$CHANGED"
+
+            # Files that don't affect build or tests
+            ACCESSORY_PATTERN='\.md$|^LICENSE|^\.gitignore$|^\.gitattributes$|^\.editorconfig$|^CODEOWNERS$'
+            NON_ACCESSORY=$(echo "$CHANGED" | grep -vE "$ACCESSORY_PATTERN" || true)
+
+            if [ -z "$NON_ACCESSORY" ]; then
+              BUILD_TYPE="skip"
+              echo "Only accessory files changed. Skipping build and tests."
+            else
+              NON_DOCS=$(echo "$NON_ACCESSORY" | grep -vE '^documentation/' || true)
+              if [ -z "$NON_DOCS" ]; then
+                BUILD_TYPE="docs-only"
+                echo "Only documentation files changed. Building docs only."
+              else
+                BUILD_TYPE="full"
+                echo "Code changes detected. Full build required."
+              fi
+            fi
+          fi
+
+          echo "Build type: $BUILD_TYPE"
+          echo "build-type=$BUILD_TYPE" >> "$GITHUB_OUTPUT"
+          echo -n "$BUILD_TYPE" > build-type.txt
+
+      - name: Upload build type
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-type
+          path: build-type.txt
+
   build:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.build-type == 'full'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -37,4 +96,17 @@ jobs:
           name: server-version
           path: |
             server-version.txt
+
+  build-docs:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.build-type == 'docs-only'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
+
+      - name: Build Documentation
+        run: ./mvnw install -B -pl documentation -am -DskipTests
 

--- a/.github/workflows/on_propen_push_do_build.yml
+++ b/.github/workflows/on_propen_push_do_build.yml
@@ -108,5 +108,5 @@ jobs:
         uses: ./.github/actions/setup-java
 
       - name: Build Documentation
-        run: ./mvnw install -B -pl documentation -am -DskipTests -Pdocumentation
+        run: ./mvnw install -B -pl documentation -am -DskipTests -Pdistribution
 

--- a/.github/workflows/operator_ci.yaml
+++ b/.github/workflows/operator_ci.yaml
@@ -5,10 +5,26 @@ on:
     branches:
       - main
       - '*.0.x'
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.editorconfig'
+      - 'CODEOWNERS'
+      - 'documentation/**'
   pull_request:
     branches:
       - main
       - '*.0.x'
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.editorconfig'
+      - 'CODEOWNERS'
+      - 'documentation/**'
 
 concurrency:
   # Cancel jobs same head_branch same repo, works

--- a/.github/workflows/pull_request_native_cli.yml
+++ b/.github/workflows/pull_request_native_cli.yml
@@ -6,11 +6,27 @@ on:
       - feature/*
       - main
       - 15.*.x
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.editorconfig'
+      - 'CODEOWNERS'
+      - 'documentation/**'
   pull_request:
     branches:
       - feature/*
       - main
       - 15.*.x
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.editorconfig'
+      - 'CODEOWNERS'
+      - 'documentation/**'
 
 concurrency:
   # Cancel jobs same head_branch same repo, works

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.editorconfig'
+      - 'CODEOWNERS'
+      - 'documentation/**'
 
 jobs:
   spotbugs:

--- a/documentation/src/main/asciidoc/topics/contributing/help.adoc
+++ b/documentation/src/main/asciidoc/topics/contributing/help.adoc
@@ -1,5 +1,6 @@
 = Helping Others Out
 
+// CI docs-only test
 {brandname} is reliant on the whole community helping each other out.
 Less experienced contributors are often able to help out answering the "newbie" questions, leaving more experienced contributors to handle the more complex questions.
 


### PR DESCRIPTION
This PR only changes a file under `documentation/`. The `detect-changes` job should classify this as `build-type=docs-only`.

**Expected behavior:**
- `detect-changes` job runs and outputs `docs-only`
- `build` job is skipped
- `build-docs` job runs and builds the documentation module
- Test workflow: all test jobs are skipped